### PR TITLE
feat: normalize all text/src file line endings and indentation (use spaces over tabs)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,4 +2,4 @@ root = true
 
 [*.{c,h,sh,conf}]
 indent_style = space
-indent_size = 4
+indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,5 @@
 root = true
 
-[*.{c,h,cmake,txt,conf,md}]
-indent_style = tab
+[*.{c,h,sh,conf}]
+indent_style = space
 indent_size = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*.{c,h,cmake,txt,conf,md}]
+indent_style = tab
+indent_size = 4

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+*.c     filter=tabspace
+*.h     filter=tabspace
+*.sh    filter=tabspace
+*.conf  filter=tabspace
+
+# Auto detect text files and perform LF normalization
+* text=auto


### PR DESCRIPTION
Like in title, it should automatically solve mistakes like in #25. I've also recursively scanned entire git history and force replaced all tabs into spaces so there should be 0 tabs in entire project.